### PR TITLE
Add tests for joinSession/treesLatest call synchronization

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -276,7 +276,7 @@ export class EpochTrackerWithRedemption extends EpochTracker {
         // It is joinSession failing with 404.
         // Repeat after waiting for treeLatest succeeding (of fail if it fails).
         // No special handling after first call - if file has been deleted, then it's game over.
-        await this.treesLatestDeferral.addListenerWithCallback();
+        await this.treesLatestDeferral.triggerCallbackAndAwaitPromise();
         return super.fetchAndParseAsJSON<T>(url, fetchOptions, fetchType, addInBody);
     }
 }
@@ -293,7 +293,7 @@ class DeferralWithCallback {
         this.callback = callback;
     }
 
-    async addListenerWithCallback() {
+    async triggerCallbackAndAwaitPromise() {
         if (this.callback) {
             await this.callback();
         }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -268,7 +268,7 @@ export class EpochTrackerWithRedemption extends EpochTracker {
             if (fetchType === "treesLatest") {
                 this.treesLatestDeferral.reject(error);
             }
-            if (fetchType !== "joinSession" || error.statusCode !== 404 || !completed) {
+            if (fetchType !== "joinSession" || error.statusCode !== 404 || completed) {
                 throw error;
             }
         }

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -282,7 +282,7 @@ export class EpochTrackerWithRedemption extends EpochTracker {
 }
 
 class DeferralWithCallback {
-    public readonly deferral;
+    public readonly deferral: Deferred<void>;
     private callback?: () => Promise<any>;
 
     constructor() {

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { OdspErrorType } from "@fluidframework/odsp-doclib-utils";
+import { IOdspResolvedUrl } from "../contracts";
+import { EpochTrackerWithRedemption } from "../epochTracker";
+import { ICacheEntry, LocalPersistentCache, LocalPersistentCacheAdapter } from "../odspCache";
+import { getHashedDocumentId } from "../odspUtils";
+import { mockFetch, notFound } from "./mockFetch";
+
+describe("Tests for Epoch Tracker With Redemption", () => {
+    const siteUrl = "https://microsoft.sharepoint-df.com/siteUrl";
+    const driveId = "driveId";
+    const itemId = "fileId";
+    let epochTracker: EpochTrackerWithRedemption;
+    let cache: LocalPersistentCacheAdapter;
+    const hashedDocumentId = getHashedDocumentId(driveId, itemId);
+    beforeEach(() => {
+        cache = new LocalPersistentCacheAdapter(new LocalPersistentCache());
+        epochTracker = new EpochTrackerWithRedemption(cache, new TelemetryNullLogger());
+        const resolvedUrl = ({ siteUrl, driveId, itemId } as any) as IOdspResolvedUrl;
+        epochTracker.fileEntry = {
+            docId: hashedDocumentId,
+            resolvedUrl,
+        };
+    });
+
+    it("joinSession call should succeed on retrying after any network call to the file succeeds", async () => {
+        let success: boolean = true;
+        const resolvedUrl = ({ siteUrl, driveId, itemId } as any) as IOdspResolvedUrl;
+        const cacheEntry1: ICacheEntry = {
+            key:"key1",
+            type: "snapshot",
+            file: { docId: hashedDocumentId, resolvedUrl } };
+        cache.put(cacheEntry1, { value: "val1", fluidEpoch: "epoch1", version: "0.1" }, 0);
+
+        try {
+            // We will trigger a successful call to return the value set in the cache after the failed joinSession call
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            setTimeout(async () => mockFetch({}, async () => {
+                return epochTracker.fetchFromCache(cacheEntry1, undefined, "other");
+            }), 100);
+
+            // Initial joinSession call will return 404 but after the timeout, the call will be retried and succeed
+            await mockFetch({ headers: { "x-fluid-epoch": "epoch1" } }, async () => {
+                return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession");
+            }, notFound, true);
+        } catch (error) {
+            success = false;
+        }
+        assert.strictEqual(success, true, "Join session should succeed after retrying");
+    });
+
+    it("Requests should fail if joinSession call fails and the getLatest call also fails", async () => {
+        let success: boolean = true;
+
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            setTimeout(async () => {
+                try {
+                    await mockFetch({}, async () => {
+                        return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest");
+                    }, notFound, true);
+                } catch (error) {
+                    assert.strictEqual(error.errorType, OdspErrorType.fileNotFoundOrAccessDeniedError,
+                        "Error should be file not found or access denied error");
+                }
+            }, 100);
+            await mockFetch({ headers: { "x-fluid-epoch": "epoch1" } }, async () => {
+                return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession");
+            }, notFound, true);
+        } catch (error) {
+            success = false;
+            assert.strictEqual(error.errorType, OdspErrorType.fileNotFoundOrAccessDeniedError,
+                "Error should be file not found or access denied error");
+        }
+        assert.strictEqual(success, false, "Join session should fail if treesLatest call has failed");
+    });
+});

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { TelemetryNullLogger } from "@fluidframework/common-utils";
-import { OdspErrorType } from "@fluidframework/odsp-doclib-utils";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { IOdspResolvedUrl } from "../contracts";
 import { EpochTrackerWithRedemption } from "../epochTracker";
 import { ICacheEntry, LocalPersistentCache, LocalPersistentCacheAdapter } from "../odspCache";
@@ -66,7 +66,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
                         return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest");
                     }, notFound, true);
                 } catch (error) {
-                    assert.strictEqual(error.errorType, OdspErrorType.fileNotFoundOrAccessDeniedError,
+                    assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
                         "Error should be file not found or access denied error");
                 }
             }, 100);
@@ -75,7 +75,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
             }, notFound, true);
         } catch (error) {
             success = false;
-            assert.strictEqual(error.errorType, OdspErrorType.fileNotFoundOrAccessDeniedError,
+            assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
                 "Error should be file not found or access denied error");
         }
         assert.strictEqual(success, false, "Join session should fail if treesLatest call has failed");

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -25,6 +25,7 @@ export async function mockFetch<T>(
     callback: () => Promise<T>,
     responseType = okResponse,
     restoreOnCall = false,
+    restoreAtEnd = true,
 ): Promise<T> {
     const fetchStub = sinon.stub(fetchModule, "default");
     fetchStub.callsFake(async () => {
@@ -38,6 +39,8 @@ export async function mockFetch<T>(
     try {
         return await callback();
     } finally {
-        fetchStub.restore();
+        if (restoreAtEnd) {
+            fetchStub.restore();
+        }
     }
 }

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -15,14 +15,26 @@ export const createResponse = async (response: object, ok: boolean, status: numb
         text: async () => Promise.resolve(JSON.stringify(response)),
         headers: (response as any).headers
             ? new fetchModule.Headers({ ...(response as any).headers }) : new fetchModule.Headers(),
-});
+    });
 
 export const okResponse = async (response: object) => createResponse(response, true, 200);
 export const notFound = async (response: object) => createResponse(response, false, 404);
 
-export async function mockFetch<T>(response: object, callback: () => Promise<T>): Promise<T> {
+export async function mockFetch<T>(
+    response: object,
+    callback: () => Promise<T>,
+    responseType = okResponse,
+    restoreOnCall = false,
+): Promise<T> {
     const fetchStub = sinon.stub(fetchModule, "default");
-    fetchStub.returns(okResponse(response));
+    fetchStub.callsFake(async () => {
+        // restoreOnCall needs be true if the fetch call needs to be mocked again before
+        // the callback returns
+        if (restoreOnCall) {
+            fetchStub.restore();
+        }
+        return responseType(response);
+    });
     try {
         return await callback();
     } finally {

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -64,6 +64,13 @@ export enum OdspErrorType {
      * does not match the one at the server.
      */
     epochVersionMismatch = "epochVersionMismatch",
+
+    /**
+     * File not found or access permissions denied error.
+     * This occurs when the user does not have permissions to the file, the file does not exist, or their
+     * permissions are in the process of being granted.
+     */
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
 }
 
 /**

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -64,13 +64,6 @@ export enum OdspErrorType {
      * does not match the one at the server.
      */
     epochVersionMismatch = "epochVersionMismatch",
-
-    /**
-     * File not found or access permissions denied error.
-     * This occurs when the user does not have permissions to the file, the file does not exist, or their
-     * permissions are in the process of being granted.
-     */
-    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
 }
 
 /**


### PR DESCRIPTION
- Updated the completed toggle check for if treesLates has succeeded in the epochTrackerWithRedemption
 - Added in tests for success/fail conditions