### PR TITLE
Using compact IDs

### DIFF
--- a/packages/framework/collabspaces/api-report/collabspaces.api.md
+++ b/packages/framework/collabspaces/api-report/collabspaces.api.md
@@ -24,7 +24,7 @@ export type ICollabChannel = IChannel & ICollabChannelCore;
 // @internal
 export interface ICollabChannelCore {
     // (undocumented)
-    readonly value: unknown;
+    readonly value: Serializable<unknown>;
 }
 
 // @internal (undocumented)

--- a/packages/framework/collabspaces/src/collabSpaces.ts
+++ b/packages/framework/collabspaces/src/collabSpaces.ts
@@ -788,8 +788,9 @@ export class TempCollabSpaceRuntime
 	private areEqualUuid(u1: uuidType, u2: string) {
 		// u1 could be a number (if ID compressor is On)
 		// u2 is a string.
-		// Can't use === comparison, "-5" & -5 are equal from POV of this comparison
-		return u1 == u2;
+		// Can't use === comparison, "-5" & -5 are equal from POV of this comparison.
+		// Coerse it to string to do proper comparison
+		return String(u1) == u2;
 	}
 
 	// #region ISharedMatrix

--- a/packages/framework/collabspaces/src/collabSpaces.ts
+++ b/packages/framework/collabspaces/src/collabSpaces.ts
@@ -122,6 +122,8 @@ import { DeferredChannel, DeferredChannelFactory } from "./deferreChannel";
 const matrixId = "matrix";
 const channelSummaryBlobName = "channelInfo";
 
+type uuidType = number | string;
+
 interface MatrixInternalType extends MatrixExternalType {
 	// This is channel ID modifier.
 	// Each cell could have only one active channel, but many passive channels associated with it.
@@ -473,8 +475,8 @@ export class TempCollabSpaceRuntime
 		if (cellValue === undefined) {
 			return { value: undefined, channel: undefined, channelId: undefined };
 		}
-		const rowId = this.matrix.getCell(row, 0) as unknown as string;
-		const colId = this.matrix.getCell(0, col) as unknown as string;
+		const rowId = this.matrix.getCell(row, 0) as unknown as uuidType;
+		const colId = this.matrix.getCell(0, col) as unknown as uuidType;
 		const channelId = `${rowId},${colId},${cellValue.iteration}`;
 		const channel = this.contexts.get(channelId)?.getChannel();
 
@@ -589,7 +591,7 @@ export class TempCollabSpaceRuntime
 
 		let row;
 		for (row = 1; row < rowCount; row++) {
-			if ((this.matrix.getCell(row, 0) as unknown as string) === rowId) {
+			if (this.areEqualUuid(this.matrix.getCell(row, 0) as unknown as uuidType, rowId)) {
 				break;
 			}
 		}
@@ -597,7 +599,7 @@ export class TempCollabSpaceRuntime
 
 		let col;
 		for (col = 1; col < colCount; col++) {
-			if ((this.matrix.getCell(0, col) as unknown as string) === colId) {
+			if (this.areEqualUuid(this.matrix.getCell(0, col) as unknown as uuidType, colId)) {
 				break;
 			}
 		}
@@ -672,7 +674,7 @@ export class TempCollabSpaceRuntime
 		if (saved) {
 			savedValue = {
 				...savedValue, // value, iteration, type
-				value: channel.value as string,
+				value: channel.value,
 				seq: refSeq,
 			};
 			this.matrix.setCell(row, col, savedValue);
@@ -734,7 +736,7 @@ export class TempCollabSpaceRuntime
 		}
 		let val = value.value;
 		if (channel !== undefined) {
-			val = (await channel).value as string;
+			val = (await channel).value;
 		}
 		return { value: val, type: value.type };
 	}
@@ -775,6 +777,21 @@ export class TempCollabSpaceRuntime
 
 	// #endregion IMatrixWriter
 
+	private uuid(): uuidType {
+		const compressor = this.dataStoreContext.idCompressor;
+		if (compressor !== undefined) {
+			return compressor.generateCompressedId();
+		}
+		return uuid();
+	}
+
+	private areEqualUuid(u1: uuidType, u2: string) {
+		// u1 could be a number (if ID compressor is On)
+		// u2 is a string.
+		// Can't use === comparison, "-5" & -5 are equal from POV of this comparison
+		return u1 == u2;
+	}
+
 	// #region ISharedMatrix
 
 	public insertCols(colStartArg: number, countArg: number) {
@@ -784,7 +801,7 @@ export class TempCollabSpaceRuntime
 		// generate new ID for a columns
 		while (count > 0) {
 			count--;
-			this.matrix.setCell(0, col, uuid() as unknown as MatrixInternalType);
+			this.matrix.setCell(0, col, this.uuid() as unknown as MatrixInternalType);
 			col++;
 		}
 	}
@@ -801,7 +818,7 @@ export class TempCollabSpaceRuntime
 		// generate new ID for a columns
 		while (count > 0) {
 			count--;
-			this.matrix.setCell(row, 0, uuid() as unknown as MatrixInternalType);
+			this.matrix.setCell(row, 0, this.uuid() as unknown as MatrixInternalType);
 			row++;
 		}
 	}

--- a/packages/framework/collabspaces/src/collabSpaces.ts
+++ b/packages/framework/collabspaces/src/collabSpaces.ts
@@ -790,7 +790,7 @@ export class TempCollabSpaceRuntime
 		// u2 is a string.
 		// Can't use === comparison, "-5" & -5 are equal from POV of this comparison.
 		// Coerse it to string to do proper comparison
-		return String(u1) == u2;
+		return String(u1) === u2;
 	}
 
 	// #region ISharedMatrix

--- a/packages/framework/collabspaces/src/contracts.ts
+++ b/packages/framework/collabspaces/src/contracts.ts
@@ -16,7 +16,7 @@ import { ISharedMatrix, MatrixItem } from "@fluidframework/matrix";
  * @internal
  */
 export interface ICollabChannelCore {
-	readonly value: unknown;
+	readonly value: Serializable<unknown>;
 }
 
 /** @internal */

--- a/packages/framework/collabspaces/src/test/collabSpaces.spec.ts
+++ b/packages/framework/collabspaces/src/test/collabSpaces.spec.ts
@@ -63,6 +63,7 @@ describe("Temporal Collab Spaces", () => {
 		enableGroupedBatching: true,
 		chunkSizeInBytes: 950000,
 		maxBatchSizeInBytes: 990000,
+		enableRuntimeIdCompressor: true,
 	};
 	const defaultFactory = sampleFactory();
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({


### PR DESCRIPTION
With this change, we have no guilds (if compressor is ON), but very small numbers. This makes some difference in snapshot sizes, memory consumed, especially for sparse tables,