### PR TITLE
Add deleteChildSummarizerNodeFn to IFluidDataStoreContext

### DIFF
--- a/packages/framework/collabspaces/src/collabSpaces.ts
+++ b/packages/framework/collabspaces/src/collabSpaces.ts
@@ -831,8 +831,7 @@ export class CollabSpacesRuntime
 		// represents same data, but need to double check that it's actually correct and tests
 		// have proper coverage.
 
-		// TBD(Pri0): remove cast by introducing proper API / workflow
-		(this.dataStoreContext as any).summarizerNode.deleteChild(channelId);
+		this.dataStoreContext.deleteChildSummarizerNodeFn(channelId);
 	}
 
 	// Saves or destroys channel, depending on the arguments

--- a/packages/framework/collabspaces/src/collabSpaces.ts
+++ b/packages/framework/collabspaces/src/collabSpaces.ts
@@ -831,7 +831,7 @@ export class CollabSpacesRuntime
 		// represents same data, but need to double check that it's actually correct and tests
 		// have proper coverage.
 
-		this.dataStoreContext.deleteChildSummarizerNodeFn(channelId);
+		this.dataStoreContext.deleteChildSummarizerNode(channelId);
 	}
 
 	// Saves or destroys channel, depending on the arguments

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -989,6 +989,10 @@ export abstract class FluidDataStoreContext
 			);
 	}
 
+	public deleteChildSummarizerNodeFn(id: string) {
+		this.summarizerNode.deleteChild(id);
+	}
+
 	public async uploadBlob(
 		blob: ArrayBufferLike,
 		signal?: AbortSignal,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -989,7 +989,7 @@ export abstract class FluidDataStoreContext
 			);
 	}
 
-	public deleteChildSummarizerNodeFn(id: string) {
+	public deleteChildSummarizerNode(id: string) {
 		this.summarizerNode.deleteChild(id);
 	}
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -212,7 +212,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     // @deprecated (undocumented)
     readonly createProps?: any;
     // (undocumented)
-    deleteChildSummarizerNodeFn(id: string): void;
+    deleteChildSummarizerNode(id: string): void;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     ensureNoDataModelChanges<T>(callback: () => T): T;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -212,6 +212,8 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     // @deprecated (undocumented)
     readonly createProps?: any;
     // (undocumented)
+    deleteChildSummarizerNodeFn(id: string): void;
+    // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     ensureNoDataModelChanges<T>(callback: () => T): T;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -483,7 +483,7 @@ export interface IFluidDataStoreContext
 		createParam: CreateChildSummarizerNodeParam,
 	): CreateChildSummarizerNodeFn;
 
-	deleteChildSummarizerNodeFn(id: string): void;
+	deleteChildSummarizerNode(id: string): void;
 
 	uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -483,6 +483,8 @@ export interface IFluidDataStoreContext
 		createParam: CreateChildSummarizerNodeParam,
 	): CreateChildSummarizerNodeFn;
 
+	deleteChildSummarizerNodeFn(id: string): void;
+
 	uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 
 	/**

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -326,6 +326,8 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // @deprecated (undocumented)
     createProps?: any;
     // (undocumented)
+    deleteChildSummarizerNodeFn(id: string): void;
+    // (undocumented)
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)
     ensureNoDataModelChanges<T>(callback: () => T): T;

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -326,7 +326,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // @deprecated (undocumented)
     createProps?: any;
     // (undocumented)
-    deleteChildSummarizerNodeFn(id: string): void;
+    deleteChildSummarizerNode(id: string): void;
     // (undocumented)
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -123,6 +123,12 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public deleteChildSummarizerNodeFn(
+		id: string,
+	): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
 		throw new Error("Method not implemented.");
 	}

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -123,7 +123,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
-	public deleteChildSummarizerNodeFn(
+	public deleteChildSummarizerNode(
 		id: string,
 	): void {
 		throw new Error("Method not implemented.");


### PR DESCRIPTION
Today IFluidDataStoreContext already has getCreateChildSummarizerNodeFn, so we are simply adding the deleteChildSummarizerNodeFn to support the removal of the channel from the summarizerNode.